### PR TITLE
fix: 4 bug fixes — ignoredUrls, clipboard, port conflicts, standalone warning

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -38,10 +38,13 @@ process.on("SIGTERM", cleanup);
 // Load config
 const config = loadConfig();
 setMaxRequests(config.maxRequests);
+if (config.mode === "standalone") {
+  console.warn("Warning: standalone mode is not yet implemented. Running in reactotron mode.");
+}
 
 // Start WebSocket server
 const PORT = parseInt(process.env.NETWATCH_PORT || String(config.port), 10);
-const wss = startServer(PORT);
+const wss = startServer(PORT, config.ignoredUrls);
 
 // Render Ink app
 const { waitUntilExit } = render(<App />, {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -122,7 +122,7 @@ const Footer = React.memo(function Footer() {
   );
 });
 
-function copyToClipboard(text: string): void {
+function copyToClipboard(text: string): boolean {
   const escaped = text.replace(/'/g, "'\\''");
   try {
     if (process.platform === "darwin") {
@@ -130,8 +130,9 @@ function copyToClipboard(text: string): void {
     } else {
       execSync(`printf '%s' '${escaped}' | xclip -sel clip`);
     }
+    return true;
   } catch {
-    // Clipboard not available
+    return false;
   }
 }
 
@@ -212,8 +213,8 @@ export function App() {
       const selected = filteredRequests[selectedIndex];
       if (selected) {
         const curl = toCurl(selected);
-        copyToClipboard(curl);
-        showStatus("Copied!");
+        const ok = copyToClipboard(curl);
+        showStatus(ok ? "Copied!" : "Copy failed");
       }
     } else if (input === "e" && !filterFocused) {
       setExportPrompt(true);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,29 @@
 import Fuse from "fuse.js";
 import type { StoredRequest } from "./types.js";
 
+export function matchesIgnoredUrl(url: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => {
+    // Regex: /pattern/
+    if (pattern.startsWith("/") && pattern.endsWith("/") && pattern.length > 2) {
+      return new RegExp(pattern.slice(1, -1)).test(url);
+    }
+    // Glob: contains * or ?
+    if (pattern.includes("*") || pattern.includes("?")) {
+      const re = new RegExp(
+        "^" +
+          pattern
+            .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+            .replace(/\*/g, ".*")
+            .replace(/\?/g, ".") +
+          "$",
+      );
+      return re.test(url);
+    }
+    // Substring: case-insensitive
+    return url.toLowerCase().includes(pattern.toLowerCase());
+  });
+}
+
 export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes}B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;


### PR DESCRIPTION
## Summary

- **ignoredUrls config now works** — filters requests by substring, glob (`*.bundle`), or regex (`/pattern/`) in `server.ts` before adding to store
- **Clipboard feedback is accurate** — `copyToClipboard` returns boolean, shows "Copy failed" when clipboard unavailable
- **Port conflict handling** — `WebSocketServer` error handler catches `EADDRINUSE`, prints actionable message and exits gracefully
- **Standalone mode warning** — logs warning when `mode: "standalone"` is set in `.netwatchrc` since it's not yet implemented

## Test plan

- [x] 50 tests passing (5 new for `matchesIgnoredUrl`)
- [x] `tsc --noEmit` clean
- [ ] Manual: set `ignoredUrls: ["symbolicate"]` in `.netwatchrc`, verify filtered
- [ ] Manual: start two instances on same port, verify error message
- [ ] Manual: set `mode: "standalone"`, verify warning logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)